### PR TITLE
update child poms to ref version 1.0.1-SNAPSHOT

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.kibocommerce</groupId>
         <artifactId>kibo-sdk-java</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/inventory-sdk/pom.xml
+++ b/inventory-sdk/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.kibocommerce</groupId>
         <artifactId>kibo-sdk-java</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Since the parent version was incremented, we need to increment the child poms to reference the updated parent sdk.